### PR TITLE
Better support arguments with spaces

### DIFF
--- a/try_repeat
+++ b/try_repeat
@@ -31,6 +31,6 @@ while [ $i -lt $count ]; do
     if [ $verbose -ne 0 ]; then
         echo "===> $((i + 1)): $@"
     fi
-    eval $@ || exit $?
+    "$@" || exit $?
     i=$(($i + 1))
 done


### PR DESCRIPTION
`"$@"` is a little smarter than `$@` about tokenizing arguments. And it seems to be in POSIX.

`eval` undoes all those smarts, so I've taken it out. However, I might be missing some situation that benefits from `eval`.

Test:
```
./try_repeat 1 ./count a "b c"
```
Before this change:
```
3
a
b
c
```
After:
```
2
a
b c
```

Here's what `count` looks like:
```
#!/bin/sh

echo $#
for f in "$@"
do
  echo $f
done
```